### PR TITLE
python3 support changes

### DIFF
--- a/anvil/cache.py
+++ b/anvil/cache.py
@@ -7,7 +7,7 @@ __author__ = 'benvanik@google.com (Ben Vanik)'
 
 
 import base64
-import cPickle
+import pickle
 import os
 
 

--- a/anvil/commands/build_command.py
+++ b/anvil/commands/build_command.py
@@ -50,7 +50,7 @@ class BuildCommand(ManageCommand):
 
     (result, all_target_outputs) = commandutil.run_build(cwd, args)
 
-    print 'result %s, %s outputs' % (result, len(all_target_outputs))
+    print('result %s, %s outputs' % (result, len(all_target_outputs)))
     #print all_target_outputs
 
     return 0 if result else 1

--- a/anvil/commands/completion_command.py
+++ b/anvil/commands/completion_command.py
@@ -72,14 +72,14 @@ complete -o default -F _anvil_completion anvil
     try:
       with io.open('/etc/bash_completion.d/anvil', 'wb') as f:
         f.write(file_str)
-      print 'Successfully installed to /etc/bash_completion.d/'
-      print 'Restart your shell or run the following to start completing:'
-      print '$ source /etc/bash_completion.d/anvil'
+      print('Successfully installed to /etc/bash_completion.d/')
+      print('Restart your shell or run the following to start completing:')
+      print('$ source /etc/bash_completion.d/anvil')
       return True
     except IOError as e:
-      print e
-      print 'error: unable to write to /etc/bash_completion.d/'
-      print '       try running with sudo!'
+      print(e)
+      print('error: unable to write to /etc/bash_completion.d/')
+      print('       try running with sudo!')
       return False
 
 
@@ -121,12 +121,12 @@ class CompletionCommand(ManageCommand):
   def execute(self, args, cwd):
     if not args.shell:
       self.create_argument_parser().print_help()
-      print '\nerror: please specify a shell (such as --bash)'
+      print('\nerror: please specify a shell (such as --bash)')
       return 1
 
     if not _COMPLETIONS.has_key(args.shell):
       self.create_argument_parser().print_help()
-      print '\nerror: shell environment "%s" not supported' % (args.shell)
+      print('\nerror: shell environment "%s" not supported' % (args.shell))
       return 1
 
     completion = _COMPLETIONS[args.shell]
@@ -136,6 +136,6 @@ class CompletionCommand(ManageCommand):
       else:
         return 1
     else:
-      print completion.get_profile_string()
+      print(completion.get_profile_string())
 
     return 0

--- a/anvil/commands/depends_command.py
+++ b/anvil/commands/depends_command.py
@@ -68,19 +68,19 @@ class DependsCommand(ManageCommand):
     dependencies = dep_manager.scan_dependencies(args.targets)
 
     if not len(dependencies):
-      print 'No requirements found'
+      print('No requirements found')
       return True
 
     if not args.install:
       # TODO(benvanik): prettier output
       for dependency in dependencies:
-        print dependency
+        print(dependency)
       return True
 
     # TODO(benvanik): check if running as root
     running_as_root = False
     if args.install and not running_as_root:
-      print 'Not running as root - run again with sudo'
+      print('Not running as root - run again with sudo')
       return False
 
     result = dep_manager.install_all(dependencies)

--- a/anvil/commands/deploy_command.py
+++ b/anvil/commands/deploy_command.py
@@ -83,8 +83,8 @@ class DeployCommand(ManageCommand):
     all_target_outputs.sort()
 
     # Copy results
-    print ''
-    print 'Copying results to %s:' % (args.output)
+    print('')
+    print('Copying results to %s:' % (args.output))
     for target_output in all_target_outputs:
       # Get path relative to root
       # This will contain the build-out/ etc
@@ -106,7 +106,7 @@ class DeployCommand(ManageCommand):
         os.makedirs(deploy_dir)
 
       # Copy!
-      print '%s -> %s' % (rel_path, deploy_path)
+      print('%s -> %s' % (rel_path, deploy_path))
       shutil.copy(target_output, deploy_path)
 
     return 0 if result else 1

--- a/anvil/commands/overlay_command.py
+++ b/anvil/commands/overlay_command.py
@@ -87,8 +87,8 @@ class OverlayCommand(ManageCommand):
     checked_dirs = {}
 
     # Copy results
-    print ''
-    print 'Symlinking results to %s:' % (args.output)
+    print('')
+    print('Symlinking results to %s:' % (args.output))
     skipped_links = 0
     for target_output in all_target_outputs:
       # Get path relative to root
@@ -114,12 +114,12 @@ class OverlayCommand(ManageCommand):
 
       # Link!
       if not os.path.exists(deploy_path):
-        print '%s -> %s' % (rel_path, deploy_path)
+        print('%s -> %s' % (rel_path, deploy_path))
         os.symlink(target_output, deploy_path)
       else:
         skipped_links += 1
 
     if skipped_links:
-      print '(%s skipped)' % (skipped_links)
+      print('(%s skipped)' % (skipped_links))
 
     return 0 if result else 1

--- a/anvil/commands/serve_command.py
+++ b/anvil/commands/serve_command.py
@@ -63,7 +63,7 @@ class ServeCommand(ManageCommand):
     # Initial build
     if len(args.targets):
       (result, all_target_outputs) = commandutil.run_build(cwd, args)
-      print all_target_outputs
+      print(all_target_outputs)
 
     self._launch_http_server(args.http_port, cwd)
 
@@ -107,7 +107,7 @@ class ServeCommand(ManageCommand):
         # Fallback to normal handling
         return Site.getResourceFor(self, request)
 
-    print 'Launching HTTP server on port %s...' % (port)
+    print('Launching HTTP server on port %s...' % (port))
 
     root = File(root_path)
     factory = MergedSite(root)

--- a/anvil/commands/test_command.py
+++ b/anvil/commands/test_command.py
@@ -37,6 +37,6 @@ class TestCommand(ManageCommand):
   def execute(self, args, cwd):
     (result, all_target_outputs) = commandutil.run_build(cwd, args)
 
-    print all_target_outputs
+    print(all_target_outputs)
 
     return 0 if result else 1

--- a/anvil/commands/util.py
+++ b/anvil/commands/util.py
@@ -38,7 +38,7 @@ def clean_output(cwd):
       try:
         shutil.rmtree(full_path)
       except Exception as e:
-        print 'Unable to remove %s: %s' % (full_path, e)
+        print('Unable to remove %s: %s' % (full_path, e))
         any_failed = True
   return not any_failed
 
@@ -78,7 +78,7 @@ def run_build(cwd, parsed_args):
 
   # TODO(benvanik): good logging/info - resolve rules in project and print
   #     info?
-  print 'building %s' % (parsed_args.targets)
+  print('building %s' % (parsed_args.targets))
 
   # Setup cache
   if not parsed_args.force:

--- a/anvil/context.py
+++ b/anvil/context.py
@@ -210,7 +210,7 @@ class BuildContext(object):
         in_flight_rules.remove(rule)
         # TODO(benvanik): log result/exception/etc?
         if exception: # pragma: no cover
-          print exception
+          print(exception)
         any_failed[0] = True
         _pump(previous_succeeded=False)
 
@@ -680,7 +680,7 @@ class RuleContext(object):
     rel_path = os.path.relpath(self.rule.path, self.build_env.root_path)
     rel_path = util.strip_implicit_build_name(rel_path)
 
-    print '... %20s ~ %s' % (self.rule.rule_name, rel_path)
+    print('... %20s ~ %s' % (self.rule.rule_name, rel_path))
 
     # Compute file delta
     # Note that this could be done async (somehow)
@@ -744,7 +744,7 @@ class RuleContext(object):
     self.end_time = util.timer()
     self.exception = exception
     # TODO(benvanik): real logging of rule failure
-    print '!! failed %s' % (self.rule)
+    print('!! failed %s' % (self.rule))
     if exception:
       self.deferred.errback(exception=exception)
     else:

--- a/anvil/graph.py
+++ b/anvil/graph.py
@@ -68,7 +68,7 @@ class RuleGraph(object):
       if not rule:
         raise KeyError('Rule "%s" unable to be resolved' % (rule_path))
       rules.append(rule)
-
+      print(rule)
       # If already present, ignore (no need to recurse)
       if rule.path in self.rule_nodes:
         continue

--- a/anvil/manage.py
+++ b/anvil/manage.py
@@ -144,7 +144,7 @@ def discover_commands(search_paths):
                 issubclass(command_cls, ManageCommand)):
               command = command_cls()
               command_name = command.name
-              if commands.has_key(command_name):
+              if command_name in commands:
                 raise KeyError('Command "%s" already defined' % (command_name))
               commands[command_name] = command
   return commands
@@ -296,14 +296,14 @@ def main(): # pragma: no cover
         cwd=os.getcwd(),
         commands=commands)
     if match_str and len(match_str):
-      print match_str
+      print(match_str)
     sys.exit(1)
 
   try:
     if len(sys.argv) < 2:
       raise ValueError('No command given')
     command_name = sys.argv[1]
-    if not commands.has_key(command_name):
+    if not command_name in commands:
       raise ValueError('Command "%s" not found' % (command_name))
 
     command = commands[command_name]
@@ -311,7 +311,7 @@ def main(): # pragma: no cover
                               args=sys.argv[2:],
                               cwd=os.getcwd())
   except ValueError:
-    print usage(commands)
+    print(usage(commands))
     return_code = 1
   except Exception as e:
     #print e

--- a/anvil/module.py
+++ b/anvil/module.py
@@ -84,9 +84,10 @@ class Module(object):
     Raises:
       NameError: The given rule name was invalid.
     """
-    if len(rule_name) and rule_name[0] == ':':
-      rule_name = rule_name[1:]
-    if not len(rule_name):
+    print(rule_name)
+    if rule_name or rule_name[0] == ':':
+      rule_name = rule_name
+    if not rule_name:
       raise NameError('Rule name "%s" is invalid' % (rule_name))
     return self.rules.get(rule_name, None)
 
@@ -184,7 +185,8 @@ class ModuleLoader(object):
       self._add_builtins(scope)
 
       # Execute!
-      exec self.code_obj in scope
+      if self.code_obj in scope:
+        exec(self.code_obj)
     finally:
       self._current_scope = None
       all_rules = anvil.rule.end_capturing_emitted_rules()

--- a/anvil/project.py
+++ b/anvil/project.py
@@ -131,7 +131,8 @@ class Project(object):
     """
     if not anvil.util.is_rule_path(rule_path):
       raise NameError('The rule path "%s" is missing a semicolon' % (rule_path))
-    (module_path, rule_name) = string.rsplit(rule_path, ':', 1)
+    (module_path, rule_name) = rule_path.split(':')
+    print(rule_name)
     if self.module_resolver.can_resolve_local:
       if not len(module_path) and not requesting_module:
         module_path = '.'

--- a/anvil/rule.py
+++ b/anvil/rule.py
@@ -227,7 +227,7 @@ class RuleNamespace(object):
       rule_type: Rule type.
     """
     rule_name = rule_type.rule_name
-    if self.rule_types.has_key(rule_name):
+    if rule_name in self.rule_types:
       raise KeyError('Rule type "%s" already defined' % (rule_name))
     self.rule_types[rule_name] = rule_type
 

--- a/anvil/rules/closure_js_rules.py
+++ b/anvil/rules/closure_js_rules.py
@@ -507,15 +507,15 @@ class JsDependencyGraph(object):
 
   def _add_dependencies(self, deps_list, namespace):
     if not namespace in self._provide_map:
-      print 'Namespace %s not provided' % (namespace)
+      print('Namespace %s not provided' % (namespace))
     assert namespace in self._provide_map
     dep_file = self._provide_map[namespace]
     if dep_file.src_path in deps_list:
       return
     for require in dep_file.requires:
       if require in dep_file.provides:
-        print 'Namespace %s both provided and required in the same file' % (
-            require)
+        print('Namespace %s both provided and required in the same file' % (
+            require))
       assert not require in dep_file.provides
       self._add_dependencies(deps_list, require)
     deps_list.append(dep_file.src_path)

--- a/anvil/task.py
+++ b/anvil/task.py
@@ -106,12 +106,12 @@ class MakoTemplateTask(Task):
     try:
       template = Template(template_contents)
     except Exception as e:
-      print 'Error in template file %s:\n%s' % (self.template_path, e)
+      print('Error in template file %s:\n%s' % (self.template_path, e))
       return False
     try:
       result = template.render_unicode(**self.template_args)
     except Exception as e:
-      print 'Error applying template %s:\n%s' % (self.template_path, e)
+      print('Error applying template %s:\n%s' % (self.template_path, e))
       return False
     with io.open(self.path, 'wt') as f:
       f.write(result)
@@ -167,7 +167,7 @@ class ExecutableTask(Task):
                            stderr=subprocess.PIPE,
                            env=env)
     except:
-      print 'unable to open process'
+      print('unable to open process')
       raise ExecutableError()
 
     # TODO(benvanik): would be nice to support a few modes here - enabling
@@ -176,11 +176,11 @@ class ExecutableTask(Task):
     (stdoutdata, stderrdata) = p.communicate()
 
     if len(stdoutdata) or len(stderrdata):
-      print '\n%s:' % (self.pretty_name)
+      print('\n%s:' % (self.pretty_name))
       if len(stdoutdata):
-        print stdoutdata
+        print(stdoutdata)
       if len(stderrdata):
-        print stderrdata
+        print(stderrdata)
 
     return_code = p.returncode
     if return_code != 0:
@@ -347,7 +347,7 @@ class InProcessTaskExecutor(TaskExecutor):
       result = task.execute()
       deferred.callback(result)
     except Exception as e:
-      print 'exception in task:'
+      print('exception in task:')
       traceback.print_exc(e)
       deferred.errback(exception=e)
     return deferred
@@ -383,12 +383,12 @@ class MultiProcessTaskExecutor(TaskExecutor):
       self._pool = multiprocessing.Pool(processes=self.worker_count,
                                         initializer=_task_initializer)
     except OSError as e: # pragma: no cover
-      print e
-      print 'Unable to initialize multiprocessing!'
+      print(e)
+      print('Unable to initialize multiprocessing!')
       if sys.platform == 'cygwin':
-        print ('Cygwin has known issues with multiprocessing and there\'s no '
-               'workaround. Boo!')
-      print 'Try running with -j1 to disable multiprocessing'
+        print(('Cygwin has known issues with multiprocessing and there\'s no '
+               'workaround. Boo!'))
+      print('Try running with -j1 to disable multiprocessing')
       raise
 
   def run_task_async(self, task):

--- a/anvil/util.py
+++ b/anvil/util.py
@@ -111,12 +111,12 @@ def is_rule_path(value):
   """
   if not isinstance(value, str) or not len(value):
     return False
-  semicolon = string.rfind(value, ':')
+  semicolon = value.rfind(':')
   if semicolon < 0:
     return False
   # Must be just a valid literal after, no path separators
-  if (string.find(value, '\\', semicolon) >= 0 or
-      string.find(value, '/', semicolon) >= 0):
+  if (value.find('\\', semicolon) >= 0 or
+      value.find('/', semicolon) >= 0):
     return False
   return True
 


### PR DESCRIPTION
- print and exec used as function calls. 
- cPickle no longer needed instead used as pickle.
- has_key deprecated changed it to `in` 

still getting this error on using the rules specified in the building docs for google/tracing-framework

```
  File "C:\github\tracing-framework\third_party\anvil-build\\anvil\..\anvil\cont
ext.py", line 187, in execute_async
    raise KeyError('Target rule "%s" not found in project' % (rule_name))
KeyError: 'Target rule ":injector" not found in project'
```

OS - windows 7
