### PR TITLE
Fix test failure and restructure the BuildContext execution.

### DIFF
--- a/anvil/context_test.py
+++ b/anvil/context_test.py
@@ -152,19 +152,31 @@ class BuildContextTest(FixtureTestCase):
       results = ctx.get_rule_results('m:b')
       self.assertEqual(results[0], Status.FAILED)
 
+    print '*******************************************************'
     project = Project(modules=[Module('m', rules=[
         FailRule('a'),
-        SucceedRule('b', deps=[':a'])])])
+        SucceedRule('b', deps=[':a']),
+        SucceedRule('c'),
+        SucceedRule('d', deps=[':c']),
+        SucceedRule('e', deps=[':c']),
+        SucceedRule('f', deps=[':d', ':e'])])])
     with BuildContext(self.build_env, project, stop_on_error=True) as ctx:
-      d = ctx.execute_async(['m:b'])
+      d = ctx.execute_async(['m:b', 'm:f'])
       ctx.wait(d)
       self.assertErrback(d)
       results = ctx.get_rule_results('m:a')
       self.assertEqual(results[0], Status.FAILED)
       results = ctx.get_rule_results('m:b')
       self.assertEqual(results[0], Status.FAILED)
+      # Because m:a failed and stop_on_error is true, even though m:c is a
+      # succed rule, m:d, m:e and m:f should all be FAILED as well.
+      results = ctx.get_rule_results('m:d')
+      self.assertEqual(results[0], Status.FAILED)
+      results = ctx.get_rule_results('m:e')
+      self.assertEqual(results[0], Status.FAILED)
+      results = ctx.get_rule_results('m:f')
+      self.assertEqual(results[0], Status.FAILED)
 
-    # TODO(benvanik): test stop_on_error
     # TODO(benvanik): test raise_on_error
 
   def testCaching(self):
@@ -277,26 +289,29 @@ class RuleContextTest(FixtureTestCase):
     project = Project(module_resolver=FileModuleResolver(self.root_path))
     build_ctx = BuildContext(self.build_env, project)
 
-    rule = project.resolve_rule(':file_input')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
-    rule_outputs = build_ctx.get_rule_outputs(rule)
+    rule = ':file_input'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
+    rule_outputs = build_ctx.get_rule_outputs(resolved)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['a.txt']))
 
-    rule = project.resolve_rule(':local_txt')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
-    rule_outputs = build_ctx.get_rule_outputs(rule)
+    rule = ':local_txt'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
+    rule_outputs = build_ctx.get_rule_outputs(resolved)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['a.txt', 'b.txt', 'c.txt']))
 
-    rule = project.resolve_rule(':recursive_txt')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
-    rule_outputs = build_ctx.get_rule_outputs(rule)
+    rule = ':recursive_txt'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
+    rule_outputs = build_ctx.get_rule_outputs(resolved)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt']))
@@ -305,63 +320,67 @@ class RuleContextTest(FixtureTestCase):
     project = Project(module_resolver=FileModuleResolver(self.root_path))
     build_ctx = BuildContext(self.build_env, project)
 
-    rule = project.resolve_rule(':missing_txt')
+    rule = ':missing_txt'
     with self.assertRaises(OSError):
-      build_ctx._execute_rule(rule)
+      build_ctx.execute_sync([rule])
 
-    rule = project.resolve_rule(':missing_glob_txt')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
-    rule_outputs = build_ctx.get_rule_outputs(rule)
+    rule = ':missing_glob_txt'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
+    rule_outputs = build_ctx.get_rule_outputs(resolved)
     self.assertEqual(len(rule_outputs), 0)
 
-    rule = project.resolve_rule(':local_txt_filter')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
-    rule_outputs = build_ctx.get_rule_outputs(rule)
+    rule = ':local_txt_filter'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
+    rule_outputs = build_ctx.get_rule_outputs(resolved)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['a.txt', 'b.txt', 'c.txt']))
 
-    rule = project.resolve_rule(':recursive_txt_filter')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
-    rule_outputs = build_ctx.get_rule_outputs(rule)
+    rule = ':recursive_txt_filter'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
+    rule_outputs = build_ctx.get_rule_outputs(resolved)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['a.txt', 'b.txt', 'c.txt', 'd.txt', 'e.txt']))
 
-    rule = project.resolve_rule(':exclude_txt_filter')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
-    rule_outputs = build_ctx.get_rule_outputs(rule)
+    rule = ':exclude_txt_filter'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
+    rule_outputs = build_ctx.get_rule_outputs(resolved)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['dir_2', 'a.txt-a', 'b.txt-b', 'c.txt-c', 'g.not-txt', 'BUILD']))
 
-    rule = project.resolve_rule(':include_exclude_filter')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
-    rule_outputs = build_ctx.get_rule_outputs(rule)
+    rule = ':include_exclude_filter'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
+    rule_outputs = build_ctx.get_rule_outputs(resolved)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['a.txt-a', 'b.txt-b']))
 
-    rule = project.resolve_rule(':multi_exts')
-    build_ctx._execute_rule(rule)
-
-    rule = project.resolve_rule(':only_a')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
-    rule_outputs = build_ctx.get_rule_outputs(rule)
+    rule = ':only_a'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
+    rule_outputs = build_ctx.get_rule_outputs(resolved)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['a.txt-a']))
 
-    rule = project.resolve_rule(':only_ab')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
-    rule_outputs = build_ctx.get_rule_outputs(rule)
+    rule = ':only_ab'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
+    rule_outputs = build_ctx.get_rule_outputs(resolved)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['a.txt-a', 'b.txt-b']))
@@ -370,36 +389,33 @@ class RuleContextTest(FixtureTestCase):
     project = Project(module_resolver=FileModuleResolver(self.root_path))
     build_ctx = BuildContext(self.build_env, project)
 
-    rule = project.resolve_rule(':file_input')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
+    rule = ':file_input'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
     rule_outputs = build_ctx.get_rule_outputs(rule)
     self.assertNotEqual(len(rule_outputs), 0)
 
-    rule = project.resolve_rule(':rule_input')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
+    rule = ':rule_input'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
     rule_outputs = build_ctx.get_rule_outputs(rule)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['a.txt']))
 
-    rule = project.resolve_rule(':mixed_input')
-    d = build_ctx._execute_rule(rule)
-    self.assertTrue(d.is_done())
+    rule = ':mixed_input'
+    resolved = project.resolve_rule(rule)
+    success = build_ctx.execute_sync([rule])
+    self.assertTrue(success)
     rule_outputs = build_ctx.get_rule_outputs(rule)
     self.assertEqual(
         set([os.path.basename(f) for f in rule_outputs]),
         set(['a.txt', 'b.txt']))
 
-    rule = project.resolve_rule(':missing_input')
     with self.assertRaises(KeyError):
-      build_ctx._execute_rule(rule)
-
-    build_ctx = BuildContext(self.build_env, project)
-    rule = project.resolve_rule(':rule_input')
-    with self.assertRaises(RuntimeError):
-      build_ctx._execute_rule(rule)
+      build_ctx.execute_sync([':missing_input'])
 
   def _compare_path(self, result, expected):
     result = os.path.relpath(result, self.root_path)


### PR DESCRIPTION
Fix test failure with the BuildContext. The error was occurring because the stop_on_error flag was not having the intended effect.

Removed the BuildContext#_pump method and replaced it with BuildContext#_chain_rule_execution. The new method instantiates RuleContexts for each rule as it iterates through the rules that need to be built. It then uses deferreds to chain rule execution to the resolution of dependencies.
