### PR TITLE
Add Twisted as a dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ INSTALL_REQUIRES = [
     'networkx==1.7',
     'pip>=1.1',
     'Sphinx>=1.1.3',
+    'twisted>15',
     'watchdog>=0.6',
 
     # Needed for the linter - easier to just have here


### PR DESCRIPTION
anvil serve requires Twisted, but it is missing from the setup script. I
verified that Twisted v15 works, but didn't try earlier versions.